### PR TITLE
Signing offline transactions for multisig wallets

### DIFF
--- a/lib/transaction.py
+++ b/lib/transaction.py
@@ -462,6 +462,10 @@ def parse_input(vds):
         else:
             d['scriptSig'] = ''
 
+        if not Transaction.is_txin_complete(d):
+            d['value'] = vds.read_uint64()
+
+
     return d
 
 
@@ -851,13 +855,17 @@ class Transaction:
         return prevout_hash + ':%d' % prevout_n
 
     @classmethod
-    def serialize_input(self, txin, script):
+    def serialize_input(self, txin, script, estimate_size=False):
         # Prev hash and index
         s = self.serialize_outpoint(txin)
         # Script length, script, sequence
         s += var_int(len(script)//2)
         s += script
         s += int_to_hex(txin.get('sequence', 0xffffffff - 1), 4)
+        # offline signing needs to know the input value
+        if ('value' in txin   # Legacy txs
+            and not (estimate_size or self.is_txin_complete(txin))):
+            s += int_to_hex(txin['value'], 8)
         return s
 
     def set_rbf(self, rbf):


### PR DESCRIPTION
This is a fix for issue #35 - **Can't sign offline transactions for multi signature wallet**:

Offline signing needs to know the input amount.

The solution is inspired from the [Electron-Cash repository ](https://github.com/Danconnolly/electroncash/blob/master/lib/transaction.py#L605)